### PR TITLE
Fix run-tests-testbox so it fails when tests fail

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -147,8 +147,8 @@ Valid values are:
   <target name="test-ci" depends="start-server,test,stop-server">
     <fail if="mxunit.failed" message="At least one test failure!"/>
 
-    <property file="${output.dir}testbox.properties" />
-    <fail if="testbox.failed" message="At least one test failure!" />
+    <property file="${output.dir}/testbox.properties" />
+    <fail if="test.failed" message="At least one test failure!" />
   </target>
 
   <target name="test">
@@ -158,8 +158,9 @@ Valid values are:
   </target>
 
   <target description="Make output directories and run the TestBox task" name="run-tests-testbox">
-    <get dest="${output.dir}/results.txt" src="http://${server.name}:${server.port}/${test.project}/tests/ci/testbox-runner.cfm?directory=${testbox.directory}&amp;reporter=text&amp;reportPath=${basedir}/${output.dir}" verbose="true" />
-    <concat><path path="${output.dir}/output.txt" /></concat>
+    <get dest="${output.dir}/results.txt" src="http://${server.name}:${server.port}/${test.project}/tests/ci/testbox-runner.cfm?directory=${testbox.directory}&amp;reporter=text&amp;reportPath=${basedir}/${output.dir}&amp;propertiesSummary=true&amp;propertiesFilename=testbox.properties" verbose="true" />
+    <concat><path path="${output.dir}/testbox.properties" /></concat>
+    <concat><path path="${output.dir}/results.txt" /></concat>
   </target>
 
   <target description="Make output directories and run the MXUnit task" name="run-tests-mxunit">


### PR DESCRIPTION
There were a few things that were incorrect with respect to the testbox integration in cfml-ci, causing the build not to fail when testbox fails.

* testbox creates `TEST.properties` not `testbox.properties` by default
* It was looking for `testbox.failed` in the `testbox.properties` file, but testbox defines `test.failed` instead
* It had `propertiesSummary=false` by default, passed in true so it actually generates the .properties file.
* It is outputting output.txt instead of results.txt